### PR TITLE
fix(VMover): fix `MoverLerpType` enum value mismatch

### DIFF
--- a/include/zenkit/vobs/Trigger.hh
+++ b/include/zenkit/vobs/Trigger.hh
@@ -44,8 +44,8 @@ namespace zenkit {
 	};
 
 	enum class MoverLerpType : uint32_t {
-		CURVE = 0,
-		LINEAR = 1,
+		LINEAR = 0,
+		CURVE = 1,
 
 		// Deprecated entries.
 		curve ZKREM("renamed to MoverLerpType::CURVE") = CURVE,

--- a/tests/TestVobsG1.cc
+++ b/tests/TestVobsG1.cc
@@ -440,7 +440,7 @@ TEST_SUITE("vobs") {
 		CHECK_FALSE(vob.auto_link);
 		CHECK_FALSE(vob.auto_rotate);
 		CHECK_EQ(vob.speed, 0.00200023991f);
-		CHECK_EQ(vob.lerp_mode, zenkit::MoverLerpType::CURVE);
+		CHECK_EQ(vob.lerp_mode, zenkit::MoverLerpType::LINEAR);
 		CHECK_EQ(vob.speed_mode, zenkit::MoverSpeedType::SLOW_START_END);
 		CHECK_EQ(vob.keyframes, G1_MOVER_KEYFRAMES);
 		CHECK_EQ(vob.sfx_open_start, "GATE_START");

--- a/tests/TestVobsG2.cc
+++ b/tests/TestVobsG2.cc
@@ -545,7 +545,7 @@ TEST_SUITE("vobs") {
 		CHECK_FALSE(vob.auto_link);
 		CHECK_FALSE(vob.auto_rotate);
 		CHECK_EQ(vob.speed, 0.0500000007f);
-		CHECK_EQ(vob.lerp_mode, zenkit::MoverLerpType::CURVE);
+		CHECK_EQ(vob.lerp_mode, zenkit::MoverLerpType::LINEAR);
 		CHECK_EQ(vob.speed_mode, zenkit::MoverSpeedType::SLOW_START_END);
 		CHECK_EQ(vob.keyframes, G1_MOVER_KEYFRAMES);
 		CHECK_EQ(vob.sfx_open_start, "GATE_START");


### PR DESCRIPTION
Possibly mixed up because CURVE is default.

Edit: Should have run the tests before. LerpType tests pass now