### PR TITLE
Introduce DaedalusVm::top_is_reference

### DIFF
--- a/include/zenkit/DaedalusVm.hh
+++ b/include/zenkit/DaedalusVm.hh
@@ -331,6 +331,7 @@ namespace zenkit {
 		[[nodiscard]] ZKAPI std::string const& pop_string();
 		[[nodiscard]] ZKAPI std::tuple<DaedalusSymbol*, std::uint8_t, std::shared_ptr<DaedalusInstance>>
 		pop_reference();
+		[[nodiscard]] ZKAPI bool top_is_reference() const;
 
 		/// \brief Registers a Daedalus external function.
 		///

--- a/src/DaedalusVm.cc
+++ b/src/DaedalusVm.cc
@@ -587,6 +587,14 @@ namespace zenkit {
 		return {std::get<DaedalusSymbol*>(v.value), v.index, v.context};
 	}
 
+	bool DaedalusVm::top_is_reference() const {
+		if (_m_stack_ptr == 0) {
+			throw DaedalusVmException {"popping from empty stack"};
+		}
+
+		return _m_stack[_m_stack_ptr - 1].reference;
+	}
+
 	std::shared_ptr<DaedalusInstance> DaedalusVm::pop_instance() {
 		if (_m_stack_ptr == 0) {
 			throw DaedalusVmException {"popping instance from empty stack"};


### PR DESCRIPTION
This PR adds a function to inspect top record of the stack without removing it.

Need to add this one, in order to support `_@` in ikarus.
Sometimes argument for `_@` can be a reference, such as:
```
int MAXCHAR;
...
CALL_INTPARAM(_@(MAXCHAR));
```
in this case opengothic will map them into the "Ikarus memory".

and sometimes  `_@` may take an instance, that decays into an integer, such as:
```
func int LIST_END(var int LIST) {
    var ZCLIST L;
    if (!(LIST)) {
        _LIST_ERRPTR("End");
        return 0;
    };
    L = _^(LIST);
    WHILE(L.NEXT);
    L = _^(L.NEXT);
    END;
    return _@(10426);
}
```
In that case `10426` is ID of the symbol `LIST_END.L`, and instance associated with it need to be returned by pointer.